### PR TITLE
Add mathtools

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -103,6 +103,7 @@ tlmgr install \
   logreq \
   marginnote \
   mathspec \
+  mathtools \
   pgf \
   pgfplots \
   preprint \


### PR DESCRIPTION
This PR adds mathtools to the list of LaTeX packages. In https://github.com/JuliaCon/proceedings-review/issues/109 I noticed that it is not installed by default but I think - arguably biased - that it would be useful for other submissions as well.

Copied from https://github.com/JuliaCon/proceedings-review/issues/109#issuecomment-1347331949:

> I always use/load mathtools instead of amsmath since it fixes some bugs in amsmath and provides useful additional functionality (see, e.g., https://ftp.acc.umu.se/mirror/CTAN/macros/latex/contrib/mathtools/mathtools.pdf). Here, it seems it is only required for \coloneqq commands. I replaced them with := which hopefully should fix whedon's compilation issues. I think it would be useful nevertheless to support mathtools, as I said it's the package I load for math support in all my LaTeX files and at least I assumed that it is a quite common package.