### PR TITLE
Update to TeXLive 2022

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 
-TEXLIVE_REPOSITORY="ftp://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2017/tlnet-final"
+TEXLIVE_REPOSITORY="ftp://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2022/tlnet-final"
 
 # TODO: remove this in future versions.
 # This is only kept for backwards support


### PR DESCRIPTION
Another thing (cf #3) I noticed when debugging whedon issues in https://github.com/JuliaCon/proceedings-review/issues/109 is that TeXLive 2017 is used. I guess for many LaTeX packages it is fine to work with the version from 2017 but e.g. for pgfplots (which was added in #2) it is limiting since one cannot use any more recent features (moreover, it turned out that the resulting compilation errors - due to a too high compat entry for pgfplots - are quite difficult to debug).

Therefore in this PR I propose to update the TeXLive installation to a more recent version.