### PR TITLE
Add orcidlink

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -106,6 +106,7 @@ tlmgr install \
   pgf \
   pgfplots \
   preprint \
+  orcidlink \
   seqsplit \
   siunitx \
   tcolorbox \


### PR DESCRIPTION
Similar to https://github.com/openjournals/heroku-buildpack-tex/pull/3, in https://github.com/JuliaCon/proceedings-review/issues/109 I noticed that orcidlink is not installed by default, even though e.g. the metadata template of the JuliaCon proceedings contains orcid IDs (https://github.com/JuliaCon/JuliaConSubmission.jl/blob/d574a4f172a1074abbf23f93719f9811bfeaa7c3/paper/paper.yml).